### PR TITLE
Enable logging when provider is initialized

### DIFF
--- a/parsec-openssl-provider/Cargo.toml
+++ b/parsec-openssl-provider/Cargo.toml
@@ -13,3 +13,4 @@ edition = "2021"
 parsec-openssl2 = { path = "../parsec-openssl2" }
 openssl-errors = "0.2.0"
 log = "0.4"
+env_logger = "0.11.2"

--- a/parsec-openssl-provider/src/lib.rs
+++ b/parsec-openssl-provider/src/lib.rs
@@ -27,6 +27,9 @@ pub unsafe fn parsec_provider_provider_init(
     out: *mut *const OSSL_DISPATCH,
     provctx: types::VOID_PTR_PTR,
 ) -> Result<(), parsec_openssl2::Error> {
+
+    env_logger::init();
+
     let parsec_provider_gettable_params_ptr: ProviderGettableParamsPtr =
         parsec_provider_gettable_params;
 


### PR DESCRIPTION
Currently, errors are not displayed when they ocurr as there is no actual logger that has been included.

 * Add env_logger as the logging unit.
 * Initialize the logging unit when the provider is initialized.