### PR TITLE
ci: Add nightly pipeline

### DIFF
--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -1,0 +1,45 @@
+name: Nightly Checks
+
+on:
+  schedule:
+    # Every night at midnight
+    - cron: "0 0 * * *"
+  workflow_dispatch:
+    inputs:
+      rev:
+        description: "Revision hash to run against"
+        required: false
+        default: ""
+
+jobs:
+  dependencies:
+    name: Check for unused dependencies
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+        with:
+          ref: "${{ github.event.inputs.rev }}"
+      - name: Install latest Rust
+        uses: actions-rs/toolchain@v1
+        with:
+          toolchain: nightly
+      - name: Install cargo udeps
+        run: cargo install cargo-udeps --locked
+      - name: Execute cargo udeps
+        run: cargo +nightly udeps
+
+  audit:
+    name: Check for crates with security vulnerabilities
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+        with:
+          ref: "${{ github.event.inputs.rev }}"
+      - name: Install latest Rust
+        uses: actions-rs/toolchain@v1
+        with:
+          toolchain: nightly
+      - name: Install cargo audit
+        run: cargo install cargo-audit
+      - name: Execute cargo audit
+        run: cargo audit


### PR DESCRIPTION
Adds audit and udpes tests on the nightly pipeline.

Signed-off-by: Gowtham Suresh Kumar <gowtham.sureshkumar@arm.com>