### PR TITLE
provider: Create ParsecProviderOperationId

### DIFF
--- a/parsec-openssl-provider/Cargo.toml
+++ b/parsec-openssl-provider/Cargo.toml
@@ -16,3 +16,5 @@ parsec-client = { git = "https://github.com/parallaxsecond/parsec-client-rust", 
 parsec-openssl2 = { path = "../parsec-openssl2" }
 openssl-errors = "0.2.0"
 env_logger = "0.10.2"
+num-traits = "0.2.18"
+num-derive = "0.4.2"


### PR DESCRIPTION
OSSL_OP_SIGNATURE was being marked as an unreachable path in the match branch, due to match syntax.