### PR TITLE
load_key tests: Re-route to the parsec provider

### DIFF
--- a/ci.sh
+++ b/ci.sh
@@ -101,7 +101,7 @@ if [ "$TEST" == "True" ]; then
     # The parsec-openssl-provider-shared-test/src/lib.rs contains some unit tests from the generated
     # test bindings from bindgen. So run only the integration tests in the test crate. 
     pushd parsec-openssl-provider-shared-test/
-    cargo test --test '*'
+    cargo test --test '*' -- --nocapture
     popd
 fi
 

--- a/parsec-openssl-provider-shared-test/src/lib.rs
+++ b/parsec-openssl-provider-shared-test/src/lib.rs
@@ -19,7 +19,7 @@ pub use parsec_openssl_provider::parsec_openssl2::openssl::{lib_ctx::LibCtx, pro
 
 // These needs to be replaced with consts from the key management module
 pub const PARSEC_PROVIDER_RSA: &[u8; 4] = b"RSA\0";
-pub const PARSEC_PROVIDER_PROPERTY: &[u8; 17] = b"provider=default\0";
+pub const PARSEC_PROVIDER_PROPERTY: &[u8; 16] = b"provider=parsec\0";
 
 // Loads a provider into the given library context
 pub fn load_provider(lib_ctx: &LibCtx, provider_name: &str, provider_path: String) -> Provider {
@@ -41,7 +41,6 @@ pub unsafe fn load_key(lib_ctx: &LibCtx, param: *mut OSSL_PARAM, parsec_pkey: *m
         EVP_PKEY_fromdata(
             evp_ctx,
             parsec_pkey as _,
-            // Change 3: Select the appropriate macro here to load the param value
             EVP_PKEY_KEY_PARAMETERS.try_into().unwrap(),
             param,
         ),

--- a/parsec-openssl-provider-shared-test/tests/provider.rs
+++ b/parsec-openssl-provider-shared-test/tests/provider.rs
@@ -2,6 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 use parsec_openssl_provider::parsec_openssl2::{openssl_binding, ossl_param};
+use parsec_openssl_provider::PARSEC_PROVIDER_KEY_NAME;
 use parsec_openssl_provider_shared_test::*;
 use std::ffi::CStr;
 
@@ -30,24 +31,21 @@ fn test_parsec_provider_name() {
 }
 
 // Loads a keys from the provider and returns an EVP_PKEY object with the details.
-// ToDo: This is working with the default provider and currently loads a key with
-// no parameters. In order to test it with the parsec provider 3 changes are needed
-// explained in comments below.
 #[test]
 fn test_loading_keys() {
     let provider_path = String::from("../target/debug/");
-    // Change 1: name the parsec provider here
-    let provider_name = String::from("default");
+    let provider_name = String::from("libparsec_openssl_provider_shared");
 
     let lib_ctx: LibCtx = LibCtx::new().unwrap();
     let provider: Provider = load_provider(&lib_ctx, &provider_name, provider_path);
 
-    // Change 2: Setup the param as needed for the parsec provider.
     // Create a key beforehand using the parsec-tool and then run the test.
-    let mut param = ossl_param!();
+    let my_key_name = "PARSEC_TEST_KEYNAME".to_string();
+    let mut param = ossl_param!(PARSEC_PROVIDER_KEY_NAME, OSSL_PARAM_UTF8_PTR, my_key_name);
     unsafe {
         let mut parsec_pkey: *mut EVP_PKEY = std::ptr::null_mut();
         load_key(&lib_ctx, &mut param, &mut parsec_pkey);
+
         EVP_PKEY_free(parsec_pkey);
     }
 }

--- a/parsec-openssl-provider/src/keymgmt/mod.rs
+++ b/parsec-openssl-provider/src/keymgmt/mod.rs
@@ -6,7 +6,7 @@ use crate::openssl_binding::{
 };
 use crate::{
     ParsecProviderContext, PARSEC_PROVIDER_DESCRIPTION_RSA, PARSEC_PROVIDER_DFLT_PROPERTIES,
-    PARSEC_PROVIDER_RSA_NAME,
+    PARSEC_PROVIDER_KEY_NAME, PARSEC_PROVIDER_RSA_NAME,
 };
 use parsec_openssl2::types::VOID_PTR;
 use parsec_openssl2::*;

--- a/parsec-openssl-provider/src/lib.rs
+++ b/parsec-openssl-provider/src/lib.rs
@@ -30,6 +30,7 @@ const PARSEC_PROVIDER_ECDSA_NAME: &[u8; 6] = b"ECDSA\0";
 const PARSEC_PROVIDER_DESCRIPTION_RSA: &[u8; 11] = b"Parsec RSA\0";
 const PARSEC_PROVIDER_DESCRIPTION_ECDSA: &[u8; 13] = b"Parsec ECDSA\0";
 const PARSEC_PROVIDER_DFLT_PROPERTIES: &[u8; 16] = b"provider=parsec\0";
+pub const PARSEC_PROVIDER_KEY_NAME: &[u8; 25] = b"parsec_provider_key_name\0";
 
 // The init function populates the dispatch table and returns a void pointer
 // to the provider context (which contains the parsec basic client).

--- a/parsec-openssl2/src/lib.rs
+++ b/parsec-openssl2/src/lib.rs
@@ -70,6 +70,15 @@ macro_rules! ossl_param {
             return_size: usize::MAX,
         }
     };
+    ($key:ident, $data_type:ident, $data:ident) => {
+        OSSL_PARAM {
+            key: $key.as_ptr() as *const std::os::raw::c_char,
+            data_type: $data_type,
+            data: $data.as_ptr() as *mut std::os::raw::c_void,
+            data_size: $data.len(),
+            return_size: usize::MAX,
+        }
+    };
 }
 
 // Finds the OpenSSL parameter type in the parameter array "params" and sets the value


### PR DESCRIPTION
The load_key test is being routed to the default provider so as to test that the test itself is correct.
Now that this is confirmed:

 * Make the load_key test route the calls to the parsec provider instead. This will now verify that the key management functions are implemented correctly.
 * Remove todos
 * Modify the ci.sh script to print required logs when running tests.

The following changes will temporarily break the CI but are necessary to test the keymanagement implementation.