### PR TITLE
Add tests/tls to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@ Cargo.lock
 .vscode
 */Cargo.lock
 */target
+tests/tls


### PR DESCRIPTION
The tests/tls directory is being created when running tls tests. As the files in here are created each time the tests are run, don't track those on the repository.