### PR TITLE
test: Add test for mismatched key and certificate

### DIFF
--- a/parsec-openssl-provider-shared/e2e_tests/tests/handshake.rs
+++ b/parsec-openssl-provider-shared/e2e_tests/tests/handshake.rs
@@ -151,3 +151,25 @@ fn test_handshake_client_authentication_with_fake_ca() {
     );
     client.connect(addr);
 }
+
+// This is a negative test case. When a client is configured with a wrong certificate for a private
+// key, the key management match function should report an error about the mismatched private key and
+// public key from the x509 certificate.
+#[test]
+fn test_client_with_mismatched_key_and_certificate() {
+    let mut ctx_builder = SslContext::builder(SslMethod::tls_client()).unwrap();
+
+    ctx_builder
+        .set_certificate_file(
+            String::from("../../tests/tls/fake_client/client_cert.pem"),
+            SslFiletype::PEM,
+        )
+        .unwrap();
+
+    ctx_builder
+        .set_private_key_file(
+            String::from("../../tests/tls/client/client_priv_key.pem"),
+            SslFiletype::PEM,
+        )
+        .unwrap_err();
+}


### PR DESCRIPTION
The key management match function compares the private key and the public key extracted from the x509 certificate when configured. This test checks if the match function is able to report an error when a wrong certificate is configured for the client.

Signed-off-by: Gowtham Suresh Kumar <gowtham.sureshkumar@arm.com>