### PR TITLE
e2e_tests/sign: Fix and simplify RSA and ECDSA signing tests

### DIFF
--- a/parsec-openssl-provider-shared/e2e_tests/Cargo.toml
+++ b/parsec-openssl-provider-shared/e2e_tests/Cargo.toml
@@ -17,6 +17,7 @@ parsec-openssl-provider = { path ="../../parsec-openssl-provider" }
 parsec-client = "0.16.0"
 sha2 = "0.10.8"
 openssl = "0.10.63"
+picky-asn1-der = "0.4.0"
 
 [build-dependencies]
 pkg-config = "0.3.18"

--- a/parsec-openssl-provider/src/lib.rs
+++ b/parsec-openssl-provider/src/lib.rs
@@ -17,7 +17,7 @@ use parsec_openssl2::types::VOID_PTR;
 use parsec_openssl2::{openssl_bindings, types};
 
 mod keymgmt;
-mod signature;
+pub mod signature;
 
 mod provider;
 use provider::*;

--- a/parsec-openssl-provider/src/signature/mod.rs
+++ b/parsec-openssl-provider/src/signature/mod.rs
@@ -18,9 +18,9 @@ use std::ffi::CStr;
 use std::sync::{Arc, RwLock};
 
 #[derive(Serialize, Deserialize)]
-struct EccSignature {
-    r: IntegerAsn1,
-    s: IntegerAsn1,
+pub struct EccSignature {
+    pub r: IntegerAsn1,
+    pub s: IntegerAsn1,
 }
 
 struct ParsecProviderSignatureContext {


### PR DESCRIPTION
     * Adapt to the fact that ECDSA signature is split and serialized.
     * Calculate hash and use the pre-computed digest for signature verification